### PR TITLE
Use spdx identifier

### DIFF
--- a/AesonBson.cabal
+++ b/AesonBson.cabal
@@ -1,6 +1,6 @@
 name:          AesonBson
 version:       0.4.1
-license:       OtherLicense
+license:       CC0-1.0
 license-file:  LICENSE
 copyright:     CC0
 author:        Niklas Hambüchen <mail@nh2.me> & Andras Slemmer <0slemi0@gmail.com>


### PR DESCRIPTION
For tools checking license compliance "OtherLicense" means nothing - so I suggest to use the corresponding SDPX identifier. See also https://cabal.readthedocs.io/en/stable/cabal-package.html#pkg-field-license and https://spdx.org/licenses/.